### PR TITLE
Feature/of 811 improve rag behaviour for diving into summary

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -10,7 +10,7 @@ import { rewardsWorkflow } from "./workflows/rewards";
 export const ragAgent = new Agent({
   name: "RAG Agent One",
   instructions: ragAgentPrompt,
-  model: openai("gpt-4o-mini"),
+  model: openai("gpt-4o"),
   tools: {
     vectorQueryTool,
   },

--- a/src/agent/prompts/rag.ts
+++ b/src/agent/prompts/rag.ts
@@ -1,12 +1,32 @@
 export const ragAgentPrompt = `
-  You are a helpful assistant that answers questions based on the provided context. Keep your answers concise and relevant.
-`;
+You are a helpful assistant for community managers. 
+Your goal is to help them better understand their community by answering questions about the conversations in the community.
 
-export const ragAgentPromptWithContext = (context: string) => `
-  You are a helpful assistant that answers questions based on the provided context. Keep your answers concise and relevant.
+Current Context:
+- Current Date: ${new Date().toLocaleDateString()}
+- Current Time: ${new Date().toLocaleTimeString()}
+- Current Unix Timestamp: ${Math.floor(Date.now() / 1000)}
 
-  Please answer the following question:
-  ${context}
+When answering:
+- Focus on factual information from the messages
+- Ask the user if they want to know about anything else
+- Mention specific users and give their username when relevant. 
+- Dont put the username in quotes. 
+- Dont put the word user before the username. e.g. user tinypellets. Just say tinypellets.
+- Keep responses concise but informative
+- Don't make assumptions beyond what's in the messages
+- Never mention the platform or the platform ID in the response, if anything say 'your community' or 'the community'
+- But share anything that may be relevant
+- Only directly quote messages if absolutely necessary
+- Don't mention that you've found messages, you should talk as if you already know the information
+- Don't resort to listing out information, if theres a lot to say then say it in a concise way. Give the high level.
+- There may be context in the vector store that isn't relevant, ignore it and only use the relevant messages.
+- Share any information about a specific topic that may be relevant to the question, especially if you do not have any other information.
 
-  Please base your answer only on the context provided in the vectorQueryTool. If the context doesn't contain enough information to fully answer the question, please state that explicitly. 
+When referring to times:
+- The timestamps returned by the vector store are in UNIX format, please make sure you accurately convert them to a human readable format
+- Mention the days the conversations took place but do so in a human way
+- Confirm that the dates are correct, if you get them wrong it will be obvious and people will not trust your answer.
+- You dont need to mention the date in every answer, only use it when it's relevant to the question.
+- Don't give the date range of the conversations, only the date specific thigns happened if relevant.
 `;

--- a/src/routes/api/v1/summaries/index.ts
+++ b/src/routes/api/v1/summaries/index.ts
@@ -72,7 +72,7 @@ summariesRoute.openapi(postAgentSummary, async (c) => {
       return c.json({ message: Errors.PLATFORM_NOT_FOUND }, 404);
     }
 
-    const startDate = createUnixTimestamp(start_date, 30);
+    const startDate = createUnixTimestamp(start_date, 15);
     const endDate = createUnixTimestamp(end_date);
 
     const ragAgent = mastra.getAgent("ragAgent");

--- a/src/routes/api/v1/summaries/index.ts
+++ b/src/routes/api/v1/summaries/index.ts
@@ -72,7 +72,7 @@ summariesRoute.openapi(postAgentSummary, async (c) => {
       return c.json({ message: Errors.PLATFORM_NOT_FOUND }, 404);
     }
 
-    const startDate = createUnixTimestamp(start_date, 15);
+    const startDate = createUnixTimestamp(start_date);
     const endDate = createUnixTimestamp(end_date);
 
     const ragAgent = mastra.getAgent("ragAgent");
@@ -97,6 +97,8 @@ Filter the context by searching the metadata.
     { timestamp: { $gte: ${startDate} } },
     { timestamp: { $lte: ${endDate} } },
   ],
+
+  Set topK to 20
  
   ${PGVECTOR_PROMPT}
 

--- a/src/routes/api/v1/summaries/routes.ts
+++ b/src/routes/api/v1/summaries/routes.ts
@@ -54,7 +54,7 @@ export const postAgentSummary = createRoute({
               .string({ message: "must be a valid ISO 8601 date format" })
               .datetime({ message: "must be a valid ISO 8601 date format" })
               .optional(),
-            endDate: z
+            end_date: z
               .string({ message: "must be a valid ISO 8601 date format" })
               .datetime({ message: "must be a valid ISO 8601 date format" })
               .optional(),


### PR DESCRIPTION
- Improved prompt based on iterative testing, it is now able to concisely answer a wide range of questions including mentioning specific users and specific times
- fixed some of the functionality around dates
- Returned 20 topk messages rather than 5 for a wider context in the response
- After testing 4o-mini and gemini-2.0-flash-001, gpt-4o  performed by far the best so moved to this model