### PR TITLE
refactor(discord): update message structure to enforce required fields and initialise checkedForReward flag

### DIFF
--- a/src/clients/discord/index.ts
+++ b/src/clients/discord/index.ts
@@ -279,6 +279,7 @@ Please search through the conversation history to find relevant information.
     text: msg.content,
     isBotQuery: msg.author.bot,
     isReaction: false,
+    checkedForReward: false,
   };
 
   // If this is a reply to another message, get the parent message's ID
@@ -315,6 +316,7 @@ discordClient.on("messageReactionAdd", async (reaction, user) => {
     text: reaction.emoji.name ?? "",
     isBotQuery: message.author.bot,
     isReaction: true,
+    checkedForReward: false,
   };
 
   // Generate embeddings for message content

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -32,12 +32,12 @@ declare global {
     authorId: string;
     authorUsername: string;
     threadId: string; // Common across platforms but implemented differently
-    channelId?: string; // Discord/Telegram specific
+    channelId: string; // Discord/Telegram specific
     timestamp: number; // Unix timestamp
     text: string;
-    isReaction?: boolean;
-    isBotQuery?: boolean;
-    checkedForReward?: boolean;
+    isReaction: boolean;
+    isBotQuery: boolean;
+    checkedForReward: boolean;
   }
 
   // Define interface for the summary metadata


### PR DESCRIPTION
### Problem
In the Discord client, the `checkedForRewards` object was not being added to the metadata before storing in the `vectorStore`. This will cause issue with future querying. 

### Solution
Add `checkedForRewards` to metadata object in `messageCreate` and `messageReactionAdd` events.