### PR TITLE
fix(discord): correct mention check for bot queries in message handling

### DIFF
--- a/src/clients/discord/index.ts
+++ b/src/clients/discord/index.ts
@@ -185,7 +185,7 @@ discordClient.on("messageCreate", async (msg) => {
 
   // Skip messages from bots and ensure we're in a guild
   if (msg.author.bot || !msg.guild) return;
-  const isBotQuery = msg.mentions.has(discordClient.user?.id ?? "");
+  const isBotQuery = msg.mentions.users.has(discordClient.user?.id ?? "");
 
   // Check for report generation command
   if (isBotQuery && cleanContent.toLowerCase().startsWith("!report")) {


### PR DESCRIPTION
## Problem
The bot was incorrectly responding to `@everyone` mentions, since it was checking `msg.mentions.has(...)`, which includes all mention types (users, roles, everyone).

## Solution
Updated the logic to specifically check `msg.mentions.users.has(...)`, ensuring the bot only responds to direct mentions and ignores `@everyone` or role pings.