### PR TITLE
refactor(db): update database connection pool settings for improved performance

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -7,15 +7,14 @@ config(); // Load environment variables
 
 export const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  max: 50, // Increased from 20 to handle more concurrent connections
-  min: 5, // Add minimum pool size to keep connections ready
-  idleTimeoutMillis: 10000, // Reduced from 30000 to free up connections faster
-  connectionTimeoutMillis: 5000, // Increased from 2000 to allow for slower network conditions
-  maxUses: 7500, // Add maximum uses per connection before being replaced
-  statement_timeout: 10000, // Add statement timeout to prevent long-running queries
-  query_timeout: 5000, // Add query timeout
+  max: 50,
+  min: 5,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 10000,
+  maxUses: 7500,
+  statement_timeout: 25000,
+  query_timeout: 20000,
 });
-
 // Add error monitoring
 pool.on("error", (err) => {
   console.error("Unexpected error on idle client", err);


### PR DESCRIPTION
### 📦 Update Postgres connection pool settings

#### Changes
- `idleTimeoutMillis`: **10000 → 30000**  
  Prevents connections from being dropped too quickly during idle periods.
- `connectionTimeoutMillis`: **5000 → 10000**  
  Adds buffer for slower network conditions.
- `statement_timeout`: **10000 → 25000**  
  Supports longer-running cron jobs (up to ~20s).
- `query_timeout`: **5000 → 20000**  
  Ensures queries from background jobs aren’t prematurely killed.

#### Why
These updates improve stability for the Discord bot and scheduled jobs, ensuring connections and long-running tasks are handled more gracefully.