### PR TITLE
fix(impact): update evidence array validation to require at least one message

### DIFF
--- a/src/agent/agents/impact.ts
+++ b/src/agent/agents/impact.ts
@@ -30,7 +30,7 @@ const impactReportSchema = z.object({
     evidence: z.array(z.object({
       channelId: z.string(),
       messageId: z.string()
-    })).min(2).max(5)
+    })).min(1).max(5)
   })),
   userSentiment: z.object({
     excitement: z.array(z.object({


### PR DESCRIPTION
### Problem
When generating impact reports, an error occurred:

`No object generated: response did not match schema`

This was caused by the evidence field requiring a minimum of 2 messages, which didn’t always align with the available data—especially for smaller or less active threads.

### Solution
Relaxed the evidence array constraint from `.min(2)` to `.min(1)` to allow the schema to validate with at least one piece of supporting evidence. This ensures impact reports can still be generated when full data is limited, improving robustness without compromising intent.