### PR TITLE
refactor(communities): enhance community data retrieval and integrate subgraph data

### DIFF
--- a/src/lib/subgraph.ts
+++ b/src/lib/subgraph.ts
@@ -2,7 +2,10 @@ import { type ChainName, getChain } from "@/constants/chains";
 import { gql, request } from "graphql-request";
 import type { Address } from "viem";
 
-export async function getCommunity(communityId: Address, chainId: keyof typeof ChainName) {
+export async function getCommunitySubgraphData(
+  communityId: Address,
+  chainId: keyof typeof ChainName,
+) {
   const GRAPHQL_URL = getChain(chainId as ChainName)?.SUBGRAPH_URL;
 
   if (!GRAPHQL_URL) {
@@ -10,21 +13,37 @@ export async function getCommunity(communityId: Address, chainId: keyof typeof C
   }
 
   const query = gql`
-    query ($communityId: ID!) {
-      app(id: $communityId) {
+    query ($app: ID!) {
+    app(id: $app) {
+    id
+    name
+    owner {
+      id
+    }
+    badges(orderBy: createdAt, orderDirection: desc) {
+      id
+      name
+      metadataURI
+      totalAwarded
+      }
+      tokens {
         id
-        name
-        owner {
+        token {
           id
+          tokenType
+          name
+          symbol
+          createdAt
         }
       }
     }
+  }
   `;
 
   const response = await request<{
     app: { name: string; owner: { id: string } };
   }>(GRAPHQL_URL, query, {
-    communityId,
+    app: communityId.toLowerCase(),
   });
 
   return response.app;

--- a/src/routes/api/v1/communities/index.ts
+++ b/src/routes/api/v1/communities/index.ts
@@ -1,21 +1,45 @@
+import { vectorStore } from "@/agent/stores";
+import type { ChainName } from "@/constants/chains";
 import { db } from "@/db";
-import { communities, platformConnections } from "@/db/schema";
+import {
+  communities,
+  pendingRewards as pendingRewardsSchema,
+  platformConnections,
+} from "@/db/schema";
 import { generateVerificationCode, storeVerificationCode } from "@/lib/redis";
+import { getCommunitySubgraphData } from "@/lib/subgraph";
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { eq } from "drizzle-orm";
-import { isAddress } from "viem";
+import { and, count, eq } from "drizzle-orm";
+import { validate as isUuid } from "uuid";
+import { type Address, isAddress } from "viem";
 import { createCommunity, generateCode, getCommunity, updateCommunity } from "./routes";
 const communitiesRoute = new OpenAPIHono();
 
 communitiesRoute.openapi(getCommunity, async (c) => {
   const id = c.req.param("id");
 
-  // First get the community by id or communityContractAddress
-  const [community] = await db
-    .select()
-    .from(communities)
-    .where(isAddress(id) ? eq(communities.communityContractAddress, id) : eq(communities.id, id))
-    .limit(1);
+  // First try to get the community by ID, but only if id is a valid UUID
+  let community = null;
+  if (isUuid(id)) {
+    [community] = await db.select().from(communities).where(eq(communities.id, id)).limit(1);
+  }
+
+  // If not found by ID, try to find by platform ID through platform connections
+  if (!community) {
+    const [platformConnection] = await db
+      .select()
+      .from(platformConnections)
+      .where(eq(platformConnections.platformId, id))
+      .limit(1);
+
+    if (platformConnection?.communityId) {
+      [community] = await db
+        .select()
+        .from(communities)
+        .where(eq(communities.id, platformConnection.communityId))
+        .limit(1);
+    }
+  }
 
   // If no community found, return 404
   if (!community) {
@@ -28,10 +52,42 @@ communitiesRoute.openapi(getCommunity, async (c) => {
     .from(platformConnections)
     .where(eq(platformConnections.communityId, community.id));
 
+  // Get all count of pending rewards for this community
+  const [{ count: pendingRewards }] = await db
+    .select({ count: count() })
+    .from(pendingRewardsSchema)
+    .where(
+      and(
+        eq(pendingRewardsSchema.community_id, community.id),
+        eq(pendingRewardsSchema.status, "pending"),
+      ),
+    );
+
+  const snapshot = await vectorStore.query({
+    indexName: "impact_reports",
+    queryVector: new Array(1536).fill(0),
+    topK: 1000,
+    includeMetadata: true,
+    filter: {
+      platformId: connections[0]?.platformId,
+    },
+  });
+
+  const sortedResults = snapshot.sort((a, b) => b.metadata.timestamp - a.metadata.timestamp);
+
+  // Get onchain data from subgraph
+  const onchainData = await getCommunitySubgraphData(
+    community.communityContractAddress as Address,
+    community.communityContractChain as ChainName,
+  );
+
   // Combine the results
   const result = {
     ...community,
     platformConnections: connections,
+    recommendations: pendingRewards,
+    onchainData: onchainData,
+    snapshot: sortedResults,
   };
 
   return c.json(result);

--- a/src/routes/api/v1/communities/routes.ts
+++ b/src/routes/api/v1/communities/routes.ts
@@ -1,6 +1,4 @@
-import { addressSchema } from "@/utils/schema";
 import { createRoute, z } from "@hono/zod-openapi";
-import { isAddress } from "viem";
 import { community, communityUpdate } from "./schema";
 
 export const getCommunity = createRoute({
@@ -8,10 +6,7 @@ export const getCommunity = createRoute({
   path: "/{id}",
   request: {
     params: z.object({
-      id: z.union([z.string().uuid(), addressSchema]).refine((val) => isAddress(val), {
-        message:
-          "Invalid community ID format. Please provide either a valid UUID or Ethereum address",
-      }),
+      id: z.string().describe("Community ID or Platform ID"),
     }),
   },
   responses: {


### PR DESCRIPTION
This PR enhances the `GET /api/v1/communities/{id}` endpoint to provide a single, flexible way for the Community Platform frontend to fetch comprehensive community data, including related platform connections, latest impact report status, pending reward recommendations count, and core on-chain data from the subgraph.

Previously, the frontend had to make multiple API calls to gather all necessary information for a community's overview and setup status. This change consolidates these calls into one, simplifying frontend logic, particularly for screens like the "Setting Up Your Community" state.

This endpoint is designed to be polled by the frontend to track the setup status of a community after linking a platform.

![Screenshot 2025-05-12 at 17 12 52](https://github.com/user-attachments/assets/ddf58d3c-8ff7-4d36-9f94-6664904602bd)


