### PR TITLE
Added combined report for communities

### DIFF
--- a/src/agent/agents/impact.ts
+++ b/src/agent/agents/impact.ts
@@ -29,6 +29,8 @@ const impactReportSchema = z.object({
     description: z.string(),
     evidence: z.array(z.object({
       channelId: z.string(),
+      platform:  z.string(),
+      platformId:  z.string(),
       messageId: z.string()
     })).min(1).max(5)
   })),
@@ -39,6 +41,8 @@ const impactReportSchema = z.object({
       users: z.array(z.string()),
       evidence: z.array(z.object({
         channelId: z.string(),
+        platform:  z.string(),
+        platformId:  z.string(),
         messageId: z.string()
       })).min(1).max(5)
     })),
@@ -48,6 +52,8 @@ const impactReportSchema = z.object({
       users: z.array(z.string()),
       evidence: z.array(z.object({
         channelId: z.string(),
+        platform:  z.string(),
+        platformId:  z.string(),
         messageId: z.string()
       })).min(1).max(5)
     }))
@@ -67,19 +73,21 @@ export const impactAgent = new Agent({
   - User sentiment analysis (what excites and frustrates users, 5-10 key points for each)
 
   For Message Examples as evidence:
-  1. Extract the channel ID from the channel section header: === Messages from Channel with Channel ID: [channelId] ===
-  2. Extract the message ID from the message: [MESSAGE_ID=messageId]
-  3. Return them in the evidence array as objects with channelId and messageId
+  1. Extract the channel ID from the channel section header: === Messages from Channel with: [Channel_ID=channelId][Platform=platform][Platform_ID=platformId] ===
+  2. Extract the Platform ID from the channel section header: === Messages from Channel with: [Channel_ID=channelId][Platform=platform][Platform_ID=platformId] ===
+  3. Extract the Platform (discord or telegram) from the channel section header: === Messages from Channel with: [Channel_ID=channelId][Platform=platform][Platform_ID=platformId] ===
+  4. Extract the message ID from the message: [MESSAGE_ID=messageId]
+  5. Return them in the evidence array as objects with channelId, platformId, platform and messageId
 
   Example:
   From transcript:
-  === Messages from Channel with Channel ID: [987654321] ===
+  === Messages from Channel with Channel ID: [Channel_ID=987654321][Platform=discord][Platform_ID=1368807851945889903] ===
   [2024-03-20] [MESSAGE_ID=111222333] username: content
 
   Should become:
-  evidence: [{ "channelId": "987654321", "messageId": "111222333" }]
+  evidence: [{ "channelId": "987654321", "platform": "discord", "platformId": "1368807851945889903", "messageId": "111222333" }]
 
-  - Only use channel IDs that appear in channel headers === Messages from Channel with Channel ID: [channelId] ===
+  - Only use channel IDs that appear in channel headers === Messages from Channel with: [Channel_ID=channelId][Platform=platform][Platform_ID=platformId] ===
   - Use the appropriate message IDs for the message you are referencing
   - Never modify or make up IDs
   - Use fewer examples if you can't find enough relevant messages
@@ -138,12 +146,14 @@ interface ImpactReportData {
     }>;
     topContributors: Array<{
       username: string;
+      platform: string;
       count: number;
     }>;
     messagesByChannel: Array<{
       channel: {
         id: string;
         name: string;
+        platform: string;
       };
       count: number;
       uniqueUsers: number;

--- a/src/agent/tools/clients/discord.ts
+++ b/src/agent/tools/clients/discord.ts
@@ -2,6 +2,10 @@ import { Client, GatewayIntentBits } from "discord.js";
 
 export async function buildChannelNameMap(channelIds: string[]): Promise<Map<string, string>> {
     const channelMap = new Map<string, string>();
+
+    if (channelIds.length === 0) {
+      return channelMap;
+    }
   
     try {
       const client = new Client({ intents: [GatewayIntentBits.Guilds] });
@@ -38,5 +42,9 @@ export async function buildChannelNameMap(channelIds: string[]): Promise<Map<str
     }
   
     return channelMap;
-  }
+}
+
+export function getMessageURL(platformId: string, channelId: string, messageId: string) {
+  return `https://discord.com/channels/${platformId}/${channelId}/${messageId}`;
+}
   

--- a/src/agent/tools/clients/index.ts
+++ b/src/agent/tools/clients/index.ts
@@ -1,0 +1,15 @@
+import { getMessageURL as getMessageURLDiscord } from "./discord";
+import { getMessageURL as getMessageURLTelegram } from "./telegram";
+
+
+export function getMessageUrlForPlatform(
+    platform:string, 
+    platformId: string, 
+    channelId: string, 
+    messageId: string
+) {
+    if (platform == "telegram") {
+        return getMessageURLTelegram(platformId, channelId, messageId);
+    }
+    return getMessageURLDiscord(platformId, channelId, messageId);
+}

--- a/src/agent/tools/clients/telegram.ts
+++ b/src/agent/tools/clients/telegram.ts
@@ -3,6 +3,11 @@ import { Telegraf } from 'telegraf';
 export async function buildChannelNameMap(channelIds: string[]): Promise<Map<string, string>> {
   const telegramClient = new Telegraf(process.env.TELEGRAM_BOT_TOKEN!);
   const channelMap = new Map<string, string>();
+
+  if (channelIds.length === 0) {
+    return channelMap;
+  }
+  
   try {
     // Filter out "unknown-channel" before making API calls
     const validChannelIds = channelIds.filter((id) => id !== "unknown-channel");
@@ -32,4 +37,16 @@ export async function buildChannelNameMap(channelIds: string[]): Promise<Map<str
   }
 
   return channelMap;
+}
+
+export function getMessageURL(platformId: string, channelId: string, messageId: string) {
+  try {
+    const channelNumber = Number.parseInt(channelId);
+    const cId = ( channelNumber >= -1997852516352 && channelNumber <= -1000000000001 ) ? 
+      Math.abs(channelNumber) - 1000000000000 : channelNumber;
+    return `https://t.me/c/${cId}/${messageId}`
+
+  } catch (err) {
+    return `error creating message URL, channel: ${channelId}, message: ${messageId}`
+  }
 }

--- a/src/agent/tools/getMessages.ts
+++ b/src/agent/tools/getMessages.ts
@@ -299,7 +299,7 @@ function formatMessagesChronologically(
 
   // Format each channel's messages
   const sections = Object.entries(messagesByChannel).map(([channelId, msgs]) => {
-    const channelHeader = `=== Messages from Channel with: [Channel_ID=${channelId}][Platform=${msgs[0].platform}][Platform_ID=${msgs[0].platformId}] ===`;
+    const channelHeader = `=== Messages from Channel with: [Channel_ID=${channelId}][Platform=${msgs[0].platform}][Platform_ID=${msgs[0].platformId}] ===\n`;
     const channelMessages = msgs
       .map((msg) => {
         const messageIdPart = includeMessageId ? ` [MESSAGE_ID=${msg.messageId}]` : "";

--- a/src/agent/tools/privyWallet.ts
+++ b/src/agent/tools/privyWallet.ts
@@ -8,6 +8,10 @@ export const createPrivyWalletTool = {
     } 
   }) => {
     try {
+      const linked_account = context.platform === "discord" ? 
+        { type: 'discord_oauth', subject: context.username, username: context.username } // Discord account
+        : { type: "telegram", telegram_user_id: context.username } // Telegram account
+
       const response = await fetch(`https://auth.privy.io/api/v1/users`, {
         method: 'POST',
         headers: {
@@ -18,11 +22,7 @@ export const createPrivyWalletTool = {
         body: JSON.stringify({
           create_ethereum_wallet: true,
           create_ethereum_smart_wallet: true,
-          linked_accounts: [{
-            type: 'discord_oauth',
-            subject: context.username,
-            username: context.username
-          }]
+          linked_accounts: [ linked_account ]
         })
       });
 

--- a/src/agent/tools/saveImpactReport.ts
+++ b/src/agent/tools/saveImpactReport.ts
@@ -28,12 +28,14 @@ export const saveImpactReportTool = createTool({
       topContributors: z.array(
         z.object({
           username: z.string(),
+          platform: z.string(),
           messageCount: z.number(),
         }),
       ),
       channelBreakdown: z.array(
         z.object({
           channelName: z.string(),
+          platform: z.string(),
           messageCount: z.number(),
           uniqueUsers: z.number(),
         }),
@@ -85,7 +87,8 @@ export const saveImpactReportTool = createTool({
       };
       startDate: number;
       endDate: number;
-      platformId: string;
+      platformId?: string;
+      communityId?: string;
       summaryId?: string;
     };
   }) => {
@@ -100,6 +103,7 @@ export const saveImpactReportTool = createTool({
 
       const reportMetadata: ImpactReportMetadata = {
         platformId: context.platformId,
+        communityId: context.communityId,
         timestamp: Date.now(),
         startDate: context.startDate,
         endDate: context.endDate,
@@ -110,6 +114,8 @@ export const saveImpactReportTool = createTool({
         keyTopics: context.report.keyTopics,
         userSentiment: context.report.userSentiment,
         summaryId: context.summaryId,
+        messageCount: context.report.overview.totalMessages,
+        uniqueUserCount: context.report.overview.uniqueUsers,
       };
 
       await vectorStore.upsert({

--- a/src/agent/tools/saveSummary.ts
+++ b/src/agent/tools/saveSummary.ts
@@ -13,7 +13,8 @@ export const saveSummaryTool = createTool({
     startDate: z.number(),
     endDate: z.number(),
     summarizationResult: z.any().optional(),
-    platformId: z.string(),
+    platformId: z.string().optional(),
+    communityId: z.string().optional(),
   }),
   outputSchema: z.object({
     success: z.boolean(),
@@ -39,6 +40,7 @@ export const saveSummaryTool = createTool({
 
       const summaryMetadata: SummaryMetadata = {
         platformId: context.platformId,
+        communityId: context.communityId,
         timestamp: dayjs().valueOf(),
         text: context.summary,
         startDate: context.startDate,

--- a/src/agent/workflows/rewards.ts
+++ b/src/agent/workflows/rewards.ts
@@ -42,7 +42,7 @@ const fetchMessagesStep = new Step({
         context: {
           startDate: context.triggerData.start_date,
           endDate: context.triggerData.end_date,
-          platformId: context.triggerData.platform_id,
+          platformIds: [context.triggerData.platform_id],
           includeStats: false,
           includeMessageId: true,
           checkedForReward: false,

--- a/src/agent/workflows/summary.ts
+++ b/src/agent/workflows/summary.ts
@@ -35,7 +35,7 @@ const fetchMessagesStep = new Step({
         context: {
           startDate: context.triggerData.startDate,
           endDate: context.triggerData.endDate,
-          platformId: context.triggerData.platformId,
+          platformIds: [context.triggerData.platformId],
           channelId: context.triggerData.channelId,
           includeStats: false,
           includeMessageId: false,

--- a/src/jobs/generate-reward-recommendations.ts
+++ b/src/jobs/generate-reward-recommendations.ts
@@ -78,6 +78,7 @@ export async function generateRewardRecommendations() {
             job_id,
             community.id,
             platformConnection.platformId,
+            platformConnection.platformType.toLowerCase(),
             dayjs().subtract(1, "year").valueOf(),
             dayjs().valueOf(),
           );

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -24,7 +24,8 @@ export interface ReportJob {
   status: ReportStatus;
   startDate: number;
   endDate: number;
-  platformId: string;
+  platformId?: string;
+  communityId?: string;
   createdAt: number;
   reportId?: string;
   error?: string;
@@ -35,7 +36,8 @@ export interface ReportJob {
  */
 export async function createReportJob(
   jobId: string,
-  platformId: string,
+  platformId: string|undefined,
+  communityId: string|undefined,
   startDate: number,
   endDate: number,
 ): Promise<ReportJob> {
@@ -45,6 +47,7 @@ export async function createReportJob(
     startDate,
     endDate,
     platformId,
+    communityId,
     createdAt: Date.now(),
   };
 

--- a/src/routes/api/v1/reports/index.ts
+++ b/src/routes/api/v1/reports/index.ts
@@ -1,6 +1,6 @@
 import { vectorStore } from "@/agent/stores/vectorStore";
 import { db } from "@/db";
-import { platformConnections } from "@/db/schema";
+import { communities, platformConnections } from "@/db/schema";
 import { ReportStatus, createReportJob, getReportJob, getReportResult } from "@/lib/redis";
 import { generateReportInBackground } from "@/services/report-generation";
 import { createUnixTimestamp } from "@/utils/time";
@@ -23,14 +23,27 @@ const reportsRoute = new OpenAPIHono();
 
 reportsRoute.openapi(generateImpactReport, async (c) => {
   try {
-    const { startDate, endDate, platformId } = c.req.query();
+    const { startDate, endDate, platformId, communityId } = c.req.query();
 
-    const platform = await db.query.platformConnections.findFirst({
-      where: eq(platformConnections.platformId, platformId as string),
-    });
+    if (platformId) {
+      const platform = await db.query.platformConnections.findFirst({
+        where: eq(platformConnections.platformId, platformId as string),
+      });
 
-    if (!platform) {
-      return c.json({ message: Errors.PLATFORM_NOT_FOUND }, 404);
+      if (!platform) {
+        return c.json({ message: Errors.PLATFORM_NOT_FOUND }, 404);
+      }
+    }
+
+    if (communityId) {
+      const community = await db.query.communities.findFirst({
+        where: eq(communities.id, communityId as string),
+      });
+
+      if (!community) {
+        return c.json({ message: Errors.COMMUNITY_NOT_FOUND }, 404);
+      }
+
     }
 
     const startTimestamp = createUnixTimestamp(startDate, 14);
@@ -38,9 +51,9 @@ reportsRoute.openapi(generateImpactReport, async (c) => {
 
     const jobId = crypto.randomUUID();
 
-    await createReportJob(jobId, platformId as string, undefined, startTimestamp, endTimestamp);
+    await createReportJob(jobId, platformId, communityId, startTimestamp, endTimestamp);
 
-    generateReportInBackground(jobId, startTimestamp, endTimestamp, platformId as string);
+    generateReportInBackground(jobId, startTimestamp, endTimestamp, platformId, communityId);
 
     // Return immediately with the job ID
     return c.json({
@@ -108,18 +121,23 @@ reportsRoute.openapi(getImpactReportStatus, async (c) => {
 
 reportsRoute.openapi(getImpactReports, async (c) => {
   try {
-    const { platformId, limit } = c.req.query();
+    const { platformId, communityId, limit } = c.req.query();
 
     const topK = limit ? Number.parseInt(limit as string) : 10;
 
+    let filter = undefined;
+    if (communityId) {
+      filter = { communityId }
+    } else if (platformId) {
+      filter = { platformId }
+    }
+    
     const results = await vectorStore.query({
       indexName: "impact_reports",
       queryVector: new Array(1536).fill(0),
       topK,
       includeMetadata: true,
-      filter: {
-        platformId,
-      },
+      filter,
     });
 
     const sortedResults = results.sort((a, b) => b.metadata.timestamp - a.metadata.timestamp);

--- a/src/routes/api/v1/reports/index.ts
+++ b/src/routes/api/v1/reports/index.ts
@@ -38,7 +38,7 @@ reportsRoute.openapi(generateImpactReport, async (c) => {
 
     const jobId = crypto.randomUUID();
 
-    await createReportJob(jobId, platformId as string, startTimestamp, endTimestamp);
+    await createReportJob(jobId, platformId as string, undefined, startTimestamp, endTimestamp);
 
     generateReportInBackground(jobId, startTimestamp, endTimestamp, platformId as string);
 

--- a/src/routes/api/v1/reports/routes.ts
+++ b/src/routes/api/v1/reports/routes.ts
@@ -8,7 +8,8 @@ export const generateImpactReport = createRoute({
   description: "Generate an impact report for a community over a specified time period",
   request: {
     query: z.object({
-      platformId: z.string().describe("Platform ID"),
+      platformId: z.string().describe("Platform ID").optional(),
+      communityId: z.string().describe("Community ID").optional(),
       startDate: z
         .string({ message: "must be a valid ISO 8601 date format" })
         .datetime({ message: "must be a valid ISO 8601 date format" })
@@ -17,7 +18,16 @@ export const generateImpactReport = createRoute({
         .string({ message: "must be a valid ISO 8601 date format" })
         .datetime({ message: "must be a valid ISO 8601 date format" })
         .optional(),
-    }),
+    })
+    .superRefine((data, ctx) => {
+    if (!data.platformId && !data.communityId) {
+       ctx.addIssue({
+         code: z.ZodIssueCode.custom,
+         path: ["communityId"],
+         message: "Required to specify communityId or platformId.",
+       });
+     }
+  }),
   },
   responses: {
     200: {
@@ -132,8 +142,14 @@ export const getImpactReports = createRoute({
   method: "get",
   path: "/impact",
   tags: ["Reports"],
-  summary: "Get all impact reports",
-  description: "Get all impact reports",
+  summary: "Get impact reports",
+  description: "Get impact reports",
+  request: {
+    query: z.object({
+      platformId: z.string().describe("Platform ID").optional(),
+      communityId: z.string().describe("Community ID").optional(),
+    })
+  },
   responses: {
     200: {
       description: "Impact reports retrieved successfully",

--- a/src/routes/api/v1/rewards/index.ts
+++ b/src/routes/api/v1/rewards/index.ts
@@ -85,7 +85,7 @@ rewardsRoute.openapi(postRewardsAnalysis, async (c) => {
     const start_timestamp = dayjs(start_date).valueOf();
     const end_timestamp = dayjs(end_date).valueOf();
 
-    await createReportJob(job_id, platform_id, start_timestamp, end_timestamp);
+    await createReportJob(job_id, platform_id, undefined, start_timestamp, end_timestamp);
 
     generateRewardsInBackground(job_id, community_id, platform_id, start_timestamp, end_timestamp);
 

--- a/src/routes/api/v1/rewards/index.ts
+++ b/src/routes/api/v1/rewards/index.ts
@@ -1,6 +1,6 @@
 import { mastra } from "@/agent";
 import { db } from "@/db";
-import { communities, pendingRewards } from "@/db/schema";
+import { communities, pendingRewards, platformConnections as platformConnectionsSchema } from "@/db/schema";
 import {
   ReportStatus,
   createReportJob,
@@ -32,6 +32,7 @@ export async function generateRewardsInBackground(
   job_id: string,
   community_id: string,
   platform_id: string,
+  platform_type: string,
   start_date: number,
   end_date: number,
 ) {
@@ -43,6 +44,7 @@ export async function generateRewardsInBackground(
       triggerData: {
         community_id,
         platform_id,
+        platform_type,
         start_date: dayjs(start_date).valueOf(),
         end_date: dayjs(end_date).valueOf(),
       },
@@ -81,13 +83,33 @@ rewardsRoute.openapi(postRewardsAnalysis, async (c) => {
       return c.json({ message: "Community not found" }, 404);
     }
 
+    const platformConnections = await db
+      .select()
+      .from(platformConnectionsSchema)
+      .where(
+        and(
+          eq(platformConnectionsSchema.communityId, community.id),
+          eq(platformConnectionsSchema.platformId, platform_id)
+        )
+      );
+    if (platformConnections.length === 0) {
+      return c.json({ message: "Provided platform does not belongs to community" }, 404);      
+    }
+
     const job_id = crypto.randomUUID();
     const start_timestamp = dayjs(start_date).valueOf();
     const end_timestamp = dayjs(end_date).valueOf();
 
     await createReportJob(job_id, platform_id, undefined, start_timestamp, end_timestamp);
 
-    generateRewardsInBackground(job_id, community_id, platform_id, start_timestamp, end_timestamp);
+    generateRewardsInBackground(
+      job_id, 
+      community_id, 
+      platform_id,
+      platformConnections.at(0)!.platformType.toLowerCase(),
+      start_timestamp, 
+      end_timestamp
+    );
 
     return c.json({
       job_id,

--- a/src/services/report-generation.ts
+++ b/src/services/report-generation.ts
@@ -8,10 +8,19 @@ export async function generateReportInBackground(
   jobId: string,
   startTimestamp: number,
   endTimestamp: number,
-  platformId: string,
+  platformId?: string,
+  communityId?: string,
 ) {
   try {
     await updateReportJobStatus(jobId, ReportStatus.PROCESSING);
+
+    if (!platformId && !communityId) {
+      console.error("Workflow failed: no community or platform");
+      await updateReportJobStatus(jobId, ReportStatus.FAILED, {
+        error: "No community or platform specified.",
+      });
+      return;
+    }
 
     const workflow = mastra.getWorkflow("impactReportWorkflow");
     const { start } = workflow.createRun();
@@ -21,6 +30,7 @@ export async function generateReportInBackground(
         startDate: startTimestamp,
         endDate: endTimestamp,
         platformId: platformId,
+        communityId: communityId,
       },
     });
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -43,7 +43,8 @@ declare global {
   // Define interface for the summary metadata
   interface SummaryMetadata {
     platform?: string;
-    platformId: string;
+    platformId?: string;
+    communityId?: string,
     timestamp: number;
     text: string;
     startDate: number;
@@ -52,16 +53,6 @@ declare global {
     coverageScore?: number | null;
     alignmentScore?: number | null;
     summarizationReason?: string | null;
-  }
-
-  interface getMessagesToolContext {
-    context: {
-      startDate: number;
-      endDate: number;
-      platformId: string;
-      includeStats?: boolean;
-      includeMessageId?: boolean;
-    };
   }
 
   interface VectorStoreResult {
@@ -100,7 +91,8 @@ declare global {
 
   // Impact Report Types
   interface ImpactReportMetadata {
-    platformId: string;
+    platformId?: string;
+    communityId?: string;
     timestamp: number;
     startDate: number;
     endDate: number;
@@ -129,11 +121,13 @@ declare global {
 
   interface TopContributor {
     username: string;
+    platform: string;
     messageCount: number;
   }
 
   interface ChannelBreakdown {
     channelName: string;
+    platform: string;
     messageCount: number;
     uniqueUsers: number;
   }


### PR DESCRIPTION
## Description

This PR adds a new type of impact report for combined platforms belonging to the same community. Combined reports generated only for communities with more than 1 platform, communities with a single platform "regular"  reports even when workflow is triggered using the `communityId`

### Changes

- Report Generation has been changed to accept a `communityId` in which case the resulting report is for all platforms belonging to that community.
- Message fetch has been changed to pull messages for several platforms.
- Message transcript has been changed to specify what platform the message comes from.
- Data aggregation is now calculated for combined messages from all platforms. Where needed a differentiation between data from different platforms is done. Example: users from Discord are not treated as the same than users from Telegram regardless they have the same username.
- IA agent has been changed to deal with the new data.
- DB storage in `impact_report` metadata now links to `communityId` (for combined reports) or to `platformId` (single platform reports)
- Cron job updated to generate combined or single report dependent on amount of platforms on each community.
- API endpoints have been updated to avoid compilation errors. No functionality has been changed in API (those changes will come in other PR)


