### PR TITLE
Integrate combined impact report into API

### DIFF
--- a/src/agent/tools/getMessages.ts
+++ b/src/agent/tools/getMessages.ts
@@ -299,7 +299,7 @@ function formatMessagesChronologically(
 
   // Format each channel's messages
   const sections = Object.entries(messagesByChannel).map(([channelId, msgs]) => {
-    const channelHeader = `=== Messages from Channel with: [Channel_ID=${channelId}][Platform=${msgs[0].platform}][Platform_ID=${msgs[0].platformId}] ===`;
+    const channelHeader = `=== Messages from Channel with: [Channel_ID=${channelId}][Platform=${msgs[0].platform}][Platform_ID=${msgs[0].platformId}] ===\n`;
     const channelMessages = msgs
       .map((msg) => {
         const messageIdPart = includeMessageId ? ` [MESSAGE_ID=${msg.messageId}]` : "";

--- a/src/agent/tools/privyWallet.ts
+++ b/src/agent/tools/privyWallet.ts
@@ -8,6 +8,10 @@ export const createPrivyWalletTool = {
     } 
   }) => {
     try {
+      const linked_account = context.platform === "discord" ? 
+        { type: 'discord_oauth', subject: context.username, username: context.username } // Discord account
+        : { type: "telegram", telegram_user_id: context.username } // Telegram account
+
       const response = await fetch(`https://auth.privy.io/api/v1/users`, {
         method: 'POST',
         headers: {
@@ -18,11 +22,7 @@ export const createPrivyWalletTool = {
         body: JSON.stringify({
           create_ethereum_wallet: true,
           create_ethereum_smart_wallet: true,
-          linked_accounts: [{
-            type: 'discord_oauth',
-            subject: context.username,
-            username: context.username
-          }]
+          linked_accounts: [ linked_account ]
         })
       });
 

--- a/src/jobs/generate-reward-recommendations.ts
+++ b/src/jobs/generate-reward-recommendations.ts
@@ -78,6 +78,7 @@ export async function generateRewardRecommendations() {
             job_id,
             community.id,
             platformConnection.platformId,
+            platformConnection.platformType.toLowerCase(),
             dayjs().subtract(1, "year").valueOf(),
             dayjs().valueOf(),
           );

--- a/src/routes/api/v1/reports/index.ts
+++ b/src/routes/api/v1/reports/index.ts
@@ -1,6 +1,6 @@
 import { vectorStore } from "@/agent/stores/vectorStore";
 import { db } from "@/db";
-import { platformConnections } from "@/db/schema";
+import { communities, platformConnections } from "@/db/schema";
 import { ReportStatus, createReportJob, getReportJob, getReportResult } from "@/lib/redis";
 import { generateReportInBackground } from "@/services/report-generation";
 import { createUnixTimestamp } from "@/utils/time";
@@ -23,14 +23,27 @@ const reportsRoute = new OpenAPIHono();
 
 reportsRoute.openapi(generateImpactReport, async (c) => {
   try {
-    const { startDate, endDate, platformId } = c.req.query();
+    const { startDate, endDate, platformId, communityId } = c.req.query();
 
-    const platform = await db.query.platformConnections.findFirst({
-      where: eq(platformConnections.platformId, platformId as string),
-    });
+    if (platformId) {
+      const platform = await db.query.platformConnections.findFirst({
+        where: eq(platformConnections.platformId, platformId as string),
+      });
 
-    if (!platform) {
-      return c.json({ message: Errors.PLATFORM_NOT_FOUND }, 404);
+      if (!platform) {
+        return c.json({ message: Errors.PLATFORM_NOT_FOUND }, 404);
+      }
+    }
+
+    if (communityId) {
+      const community = await db.query.communities.findFirst({
+        where: eq(communities.id, communityId as string),
+      });
+
+      if (!community) {
+        return c.json({ message: Errors.COMMUNITY_NOT_FOUND }, 404);
+      }
+
     }
 
     const startTimestamp = createUnixTimestamp(startDate, 14);
@@ -38,9 +51,9 @@ reportsRoute.openapi(generateImpactReport, async (c) => {
 
     const jobId = crypto.randomUUID();
 
-    await createReportJob(jobId, platformId as string, undefined, startTimestamp, endTimestamp);
+    await createReportJob(jobId, platformId, communityId, startTimestamp, endTimestamp);
 
-    generateReportInBackground(jobId, startTimestamp, endTimestamp, platformId as string);
+    generateReportInBackground(jobId, startTimestamp, endTimestamp, platformId, communityId);
 
     // Return immediately with the job ID
     return c.json({
@@ -108,18 +121,23 @@ reportsRoute.openapi(getImpactReportStatus, async (c) => {
 
 reportsRoute.openapi(getImpactReports, async (c) => {
   try {
-    const { platformId, limit } = c.req.query();
+    const { platformId, communityId, limit } = c.req.query();
 
     const topK = limit ? Number.parseInt(limit as string) : 10;
 
+    let filter = undefined;
+    if (communityId) {
+      filter = { communityId }
+    } else if (platformId) {
+      filter = { platformId }
+    }
+    
     const results = await vectorStore.query({
       indexName: "impact_reports",
       queryVector: new Array(1536).fill(0),
       topK,
       includeMetadata: true,
-      filter: {
-        platformId,
-      },
+      filter,
     });
 
     const sortedResults = results.sort((a, b) => b.metadata.timestamp - a.metadata.timestamp);

--- a/src/routes/api/v1/reports/routes.ts
+++ b/src/routes/api/v1/reports/routes.ts
@@ -8,7 +8,8 @@ export const generateImpactReport = createRoute({
   description: "Generate an impact report for a community over a specified time period",
   request: {
     query: z.object({
-      platformId: z.string().describe("Platform ID"),
+      platformId: z.string().describe("Platform ID").optional(),
+      communityId: z.string().describe("Community ID").optional(),
       startDate: z
         .string({ message: "must be a valid ISO 8601 date format" })
         .datetime({ message: "must be a valid ISO 8601 date format" })
@@ -17,7 +18,16 @@ export const generateImpactReport = createRoute({
         .string({ message: "must be a valid ISO 8601 date format" })
         .datetime({ message: "must be a valid ISO 8601 date format" })
         .optional(),
-    }),
+    })
+    .superRefine((data, ctx) => {
+    if (!data.platformId && !data.communityId) {
+       ctx.addIssue({
+         code: z.ZodIssueCode.custom,
+         path: ["communityId"],
+         message: "Required to specify communityId or platformId.",
+       });
+     }
+  }),
   },
   responses: {
     200: {
@@ -132,8 +142,14 @@ export const getImpactReports = createRoute({
   method: "get",
   path: "/impact",
   tags: ["Reports"],
-  summary: "Get all impact reports",
-  description: "Get all impact reports",
+  summary: "Get impact reports",
+  description: "Get impact reports",
+  request: {
+    query: z.object({
+      platformId: z.string().describe("Platform ID").optional(),
+      communityId: z.string().describe("Community ID").optional(),
+    })
+  },
   responses: {
     200: {
       description: "Impact reports retrieved successfully",

--- a/src/routes/api/v1/rewards/index.ts
+++ b/src/routes/api/v1/rewards/index.ts
@@ -1,6 +1,6 @@
 import { mastra } from "@/agent";
 import { db } from "@/db";
-import { communities, pendingRewards } from "@/db/schema";
+import { communities, pendingRewards, platformConnections as platformConnectionsSchema } from "@/db/schema";
 import {
   ReportStatus,
   createReportJob,
@@ -32,6 +32,7 @@ export async function generateRewardsInBackground(
   job_id: string,
   community_id: string,
   platform_id: string,
+  platform_type: string,
   start_date: number,
   end_date: number,
 ) {
@@ -43,6 +44,7 @@ export async function generateRewardsInBackground(
       triggerData: {
         community_id,
         platform_id,
+        platform_type,
         start_date: dayjs(start_date).valueOf(),
         end_date: dayjs(end_date).valueOf(),
       },
@@ -81,13 +83,33 @@ rewardsRoute.openapi(postRewardsAnalysis, async (c) => {
       return c.json({ message: "Community not found" }, 404);
     }
 
+    const platformConnections = await db
+      .select()
+      .from(platformConnectionsSchema)
+      .where(
+        and(
+          eq(platformConnectionsSchema.communityId, community.id),
+          eq(platformConnectionsSchema.platformId, platform_id)
+        )
+      );
+    if (platformConnections.length === 0) {
+      return c.json({ message: "Provided platform does not belongs to community" }, 404);      
+    }
+
     const job_id = crypto.randomUUID();
     const start_timestamp = dayjs(start_date).valueOf();
     const end_timestamp = dayjs(end_date).valueOf();
 
     await createReportJob(job_id, platform_id, undefined, start_timestamp, end_timestamp);
 
-    generateRewardsInBackground(job_id, community_id, platform_id, start_timestamp, end_timestamp);
+    generateRewardsInBackground(
+      job_id, 
+      community_id, 
+      platform_id,
+      platformConnections.at(0)!.platformType.toLowerCase(),
+      start_timestamp, 
+      end_timestamp
+    );
 
     return c.json({
       job_id,


### PR DESCRIPTION
## Description

This PR integrates new combined impact report into the API.

### Changes

- Endpoint `GET /api/v1/reports/impact` accepts filters for `communityId` | `platformId`
- Endpoint `POST /api/v1/reports/impact` triggers a combined or single platfrom report, receives a `communityId` or `platformId`
- Existing reports remain available by `/api/v1/reports/impact/:reportId`
