### PR TITLE
Added Telegram support in rewards recommendations

### DIFF
--- a/src/agent/tools/getMessages.ts
+++ b/src/agent/tools/getMessages.ts
@@ -299,7 +299,7 @@ function formatMessagesChronologically(
 
   // Format each channel's messages
   const sections = Object.entries(messagesByChannel).map(([channelId, msgs]) => {
-    const channelHeader = `=== Messages from Channel with: [Channel_ID=${channelId}][Platform=${msgs[0].platform}][Platform_ID=${msgs[0].platformId}] ===`;
+    const channelHeader = `=== Messages from Channel with: [Channel_ID=${channelId}][Platform=${msgs[0].platform}][Platform_ID=${msgs[0].platformId}] ===\n`;
     const channelMessages = msgs
       .map((msg) => {
         const messageIdPart = includeMessageId ? ` [MESSAGE_ID=${msg.messageId}]` : "";

--- a/src/agent/tools/privyWallet.ts
+++ b/src/agent/tools/privyWallet.ts
@@ -8,6 +8,10 @@ export const createPrivyWalletTool = {
     } 
   }) => {
     try {
+      const linked_account = context.platform === "discord" ? 
+        { type: 'discord_oauth', subject: context.username, username: context.username } // Discord account
+        : { type: "telegram", telegram_user_id: context.username } // Telegram account
+
       const response = await fetch(`https://auth.privy.io/api/v1/users`, {
         method: 'POST',
         headers: {
@@ -18,11 +22,7 @@ export const createPrivyWalletTool = {
         body: JSON.stringify({
           create_ethereum_wallet: true,
           create_ethereum_smart_wallet: true,
-          linked_accounts: [{
-            type: 'discord_oauth',
-            subject: context.username,
-            username: context.username
-          }]
+          linked_accounts: [ linked_account ]
         })
       });
 

--- a/src/jobs/generate-reward-recommendations.ts
+++ b/src/jobs/generate-reward-recommendations.ts
@@ -78,6 +78,7 @@ export async function generateRewardRecommendations() {
             job_id,
             community.id,
             platformConnection.platformId,
+            platformConnection.platformType.toLowerCase(),
             dayjs().subtract(1, "year").valueOf(),
             dayjs().valueOf(),
           );

--- a/src/routes/api/v1/rewards/index.ts
+++ b/src/routes/api/v1/rewards/index.ts
@@ -1,6 +1,6 @@
 import { mastra } from "@/agent";
 import { db } from "@/db";
-import { communities, pendingRewards } from "@/db/schema";
+import { communities, pendingRewards, platformConnections as platformConnectionsSchema } from "@/db/schema";
 import {
   ReportStatus,
   createReportJob,
@@ -32,6 +32,7 @@ export async function generateRewardsInBackground(
   job_id: string,
   community_id: string,
   platform_id: string,
+  platform_type: string,
   start_date: number,
   end_date: number,
 ) {
@@ -43,6 +44,7 @@ export async function generateRewardsInBackground(
       triggerData: {
         community_id,
         platform_id,
+        platform_type,
         start_date: dayjs(start_date).valueOf(),
         end_date: dayjs(end_date).valueOf(),
       },
@@ -81,13 +83,33 @@ rewardsRoute.openapi(postRewardsAnalysis, async (c) => {
       return c.json({ message: "Community not found" }, 404);
     }
 
+    const platformConnections = await db
+      .select()
+      .from(platformConnectionsSchema)
+      .where(
+        and(
+          eq(platformConnectionsSchema.communityId, community.id),
+          eq(platformConnectionsSchema.platformId, platform_id)
+        )
+      );
+    if (platformConnections.length === 0) {
+      return c.json({ message: "Provided platform does not belongs to community" }, 404);      
+    }
+
     const job_id = crypto.randomUUID();
     const start_timestamp = dayjs(start_date).valueOf();
     const end_timestamp = dayjs(end_date).valueOf();
 
     await createReportJob(job_id, platform_id, undefined, start_timestamp, end_timestamp);
 
-    generateRewardsInBackground(job_id, community_id, platform_id, start_timestamp, end_timestamp);
+    generateRewardsInBackground(
+      job_id, 
+      community_id, 
+      platform_id,
+      platformConnections.at(0)!.platformType.toLowerCase(),
+      start_timestamp, 
+      end_timestamp
+    );
 
     return c.json({
       job_id,


### PR DESCRIPTION
## Description

This PR adds Telegram support in Rewards recommendations.

### Changes:

- Added wallet generation for Telegram accounts
- Modified rewards workflow to receive platform type as trigger data. We need to know this in some steps.
- Modified `getWalletAddressesStep`, `savePendingRewards` and `identifyRewardsStep` to account for new platform type
- Evidence for Telegram platform now points to `t.me` permalink
- Modified cron job and `POST /recommendations` to retrieve and pass platform type to workflow.