### PR TITLE
Fixed time range for rewards recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.31.1](https://github.com/open-format/community-agent/compare/v0.31.0...v0.31.1) (2025-06-04)
+
+
+### Bug Fixes
+
+* Fixed retry mechanism for identifyRewardsStep batch processing ([6b03db4](https://github.com/open-format/community-agent/commit/6b03db4a76971b80e40007f7cd63242852e19c21))
+
 # [0.31.0](https://github.com/open-format/community-agent/compare/v0.30.0...v0.31.0) (2025-05-30)
 
 

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
     "pino-pretty": "^13.0.0",
     "semantic-release": "^24.2.2"
   },
-  "version": "0.31.0"
+  "version": "0.31.1"
 }

--- a/src/agent/workflows/rewards.ts
+++ b/src/agent/workflows/rewards.ts
@@ -177,19 +177,22 @@ const identifyRewardsStep = new Step({
         while (retries < maxRetries) {
           try {
             const rewards = await identifyRewards(transcript);
+
             if (rewards?.contributions && Array.isArray(rewards.contributions)) {
               allContributions = allContributions.concat(rewards.contributions);
             }
+            break;
           } catch (error) {
             retries++;
             if (retries < maxRetries) {
               logger.error(
                 `Error on identifyRewards for batch ${i + 1}, attempt ${retries}:`,
                 error instanceof Error ? error.message : error,
-              )
+              );
               // Wait 1s before next attempt
               await new Promise((resolve) => setTimeout(resolve, 1000));
-            } else { // Last retry
+            } else {
+              // Last retry
               logger.error(
                 `❌ identifyRewards failed for batch ${i + 1} after ${maxRetries} attempts:`,
                 error instanceof Error ? error.message : error,

--- a/src/jobs/generate-reward-recommendations.ts
+++ b/src/jobs/generate-reward-recommendations.ts
@@ -79,8 +79,8 @@ export async function generateRewardRecommendations() {
             community.id,
             platformConnection.platformId,
             platformConnection.platformType.toLowerCase(),
-            dayjs().subtract(1, "year").valueOf(),
-            dayjs().valueOf(),
+            dayjs().startOf("day").subtract(1, "day").valueOf(),
+            dayjs().endOf("day").valueOf(),
           );
 
           const platformDuration = Date.now() - platformStartTime;


### PR DESCRIPTION
## Description

This PR fixes the time range for rewards recommendations, from 1year to correct value of 1day.

Issue that provoked this PR was an error when encountering high volume of messages in `identifyRewardsStep`. I think error was caused by a combination of bad time range and a bug fixed in commit [hotfix: Improve error handling and retry logic in identifyRewardsStep](https://github.com/open-format/community-agent/commit/0ec617afa7abac9bc4c8d580cb48fcabaab73f17)