### PR TITLE
Using Pino log in all  endpoints that start a background job

### DIFF
--- a/src/routes/api/v1/reports/index.ts
+++ b/src/routes/api/v1/reports/index.ts
@@ -13,6 +13,7 @@ import {
   getImpactReportStatus,
   getImpactReports,
 } from "./routes";
+import { logger } from "@/services/logger";
 
 enum Errors {
   PLATFORM_NOT_FOUND = "Platform not for given community",
@@ -65,7 +66,10 @@ reportsRoute.openapi(generateImpactReport, async (c) => {
       },
     });
   } catch (error) {
-    console.error("Error starting impact report generation:", error);
+    logger.error(
+      error instanceof Error ? error : { error },
+      "Error starting impact report generation"
+    );
     return c.json({ message: "Failed to start report generation", error: String(error) }, 500);
   }
 });

--- a/src/routes/api/v1/rewards/index.ts
+++ b/src/routes/api/v1/rewards/index.ts
@@ -17,6 +17,7 @@ import {
   postRewardsAnalysis,
 } from "./routes";
 import { generateRewardsInBackground } from "@/services/rewards";
+import { logger } from "@/services/logger";
 
 enum Errors {
   COMMUNITY_NOT_FOUND = "Community not found",
@@ -70,7 +71,10 @@ rewardsRoute.openapi(postRewardsAnalysis, async (c) => {
       },
     });
   } catch (error) {
-    console.error("Error starting rewards analysis:", error);
+    logger.error(
+      error instanceof Error ? error : { error },
+      "Error starting rewards analysis"
+    );
     return c.json(
       {
         message: "Failed to start rewards analysis",

--- a/src/routes/api/v1/summaries/index.ts
+++ b/src/routes/api/v1/summaries/index.ts
@@ -14,6 +14,7 @@ import {
   getHistoricalMessagesStatus,
   postAgentSummary,
 } from "./routes";
+import { logger } from "@/services/logger";
 
 enum Errors {
   PLATFORM_NOT_FOUND = "Platform not found",
@@ -146,7 +147,7 @@ summariesRoute.openapi(getHistoricalMessages, async (c) => {
 
     const job_id = crypto.randomUUID();
 
-    await createReportJob(job_id, platform_id as string, startTimestamp, endTimestamp);
+    await createReportJob(job_id, platform_id as string, undefined, startTimestamp, endTimestamp);
 
     // Start the background job
     fetchHistoricalMessagesInBackground(
@@ -165,7 +166,10 @@ summariesRoute.openapi(getHistoricalMessages, async (c) => {
       },
     });
   } catch (error) {
-    console.error("Error starting historical message fetch:", error);
+    logger.error(
+      error instanceof Error ? error : { error },
+      "Error starting historical messages fetch"
+    );
     return c.json(
       {
         message: "Failed to start historical message fetch",

--- a/src/services/historical-messages.ts
+++ b/src/services/historical-messages.ts
@@ -1,5 +1,6 @@
 import { fetchHistoricalMessagesTool } from "@/agent/tools/fetchHistoricalMessages";
 import { ReportStatus, storeReportResult, updateReportJobStatus } from "@/lib/redis";
+import { logger } from "./logger";
 
 // Function to fetch historical messages in the background
 export async function fetchHistoricalMessagesInBackground(
@@ -36,7 +37,10 @@ export async function fetchHistoricalMessagesInBackground(
 
     await updateReportJobStatus(jobId, ReportStatus.COMPLETED);
   } catch (error) {
-    console.error("Error fetching historical messages:", error);
+    logger.error(
+      error instanceof Error ? error : { error }, 
+      "Error fetching historical messages"
+    );
     await updateReportJobStatus(jobId, ReportStatus.FAILED, {
       error: error instanceof Error ? error.message : String(error),
     });

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,0 +1,18 @@
+import pino from "pino";
+
+export const logger = pino({
+  level: process.env.PINO_LOG_LEVEL ?? "info",
+  timestamp: true,
+  formatters: {
+    level: (label) => {
+      return { level: label };
+    },
+  },
+  transport: {
+    target: "pino-pretty",
+    options: {
+      colorize: true,
+      translateTime: "SYS:standard",
+    },
+  },
+});


### PR DESCRIPTION
## Description

Currently all endpoints that start a new background job use `console.log` for logging errors. This PR modifies them in order to use a Pino logger.

Functions that are executed in background jobs have also been changed to use Pino logger.

### Changes:

Changed endpoints:

- `POST    /api/v1/reports/impact`
- `POST    /api/v1/rewards/recommendations`
- `GET     /api/v1/summaries/historical-messages`

Changed functions:

- `fetchHistoricalMessagesInBackground`
- `generateReportInBackground`
- `generateRewardsInBackground`

Added new logger service `src/services/logger.ts`
