### PR TITLE
Removed "Next Report" section in Telegram impact report

### DIFF
--- a/src/clients/telegram/commands/report.ts
+++ b/src/clients/telegram/commands/report.ts
@@ -14,15 +14,13 @@ export async function getReport(chatId: string): Promise<string> {
   });
 
   if (results.length === 0) {
-    return escapeMarkdownV2(`
+    return `
 *No Impact Report Available*
 
 There are no impact reports available for this community yet
 
-*Next Report*
-
-Impact reports are generated daily with the latest weekly data. The next report will be available soon
-`);
+Impact reports are generated daily, at midnight UTC, with the latest weekly data\\. The next report will be available soon
+`;
   }
 
   const report = results.sort((a, b) => b.metadata.timestamp - a.metadata.timestamp)[0].metadata;
@@ -56,15 +54,14 @@ ${report.keyTopics
   .map((topic) => `• ${escapeMarkdownV2(topic.topic)}`)
   .join("\n")}
 
-*📅 Next Report*
-
-The next impact report will be generated on ${escapeMarkdownV2(nextReportDate.format("MMMM D, YYYY"))}
-
 *🔗 Full Report*
 
 [View detailed report](${process.env.PLATFORM_URL}/reports/${report.summaryId})
 
 _Report generated on ${escapeMarkdownV2(dayjs(report.timestamp).format("MMMM D, YYYY"))}_
+
+
+_Impact reports are updated daily at midnight UTC_
 `;
 }
 


### PR DESCRIPTION
Case when there are no reports:

![image](https://github.com/user-attachments/assets/6f17ef93-8897-4d79-9f2a-67e9d789f65b)

Report:

![image](https://github.com/user-attachments/assets/e3e176aa-ec11-46ea-9f21-d1ed0b83f156)
