### PR TITLE
Generation of Combined and Platform-Specific Impact Reports

### DIFF
--- a/src/agent/tools/saveImpactReport.ts
+++ b/src/agent/tools/saveImpactReport.ts
@@ -88,7 +88,7 @@ export const saveImpactReportTool = createTool({
       startDate: number;
       endDate: number;
       platformId?: string;
-      communityId?: string;
+      communityId: string;
       summaryId?: string;
     };
   }) => {
@@ -102,6 +102,7 @@ export const saveImpactReportTool = createTool({
       });
 
       const reportMetadata: ImpactReportMetadata = {
+        isCombined: context.platformId ? false : true,
         platformId: context.platformId,
         communityId: context.communityId,
         timestamp: Date.now(),

--- a/src/agent/tools/saveSummary.ts
+++ b/src/agent/tools/saveSummary.ts
@@ -14,7 +14,7 @@ export const saveSummaryTool = createTool({
     endDate: z.number(),
     summarizationResult: z.any().optional(),
     platformId: z.string().optional(),
-    communityId: z.string().optional(),
+    communityId: z.string(),
   }),
   outputSchema: z.object({
     success: z.boolean(),
@@ -39,6 +39,7 @@ export const saveSummaryTool = createTool({
       });
 
       const summaryMetadata: SummaryMetadata = {
+        isCombined: context.platformId ? false : true,
         platformId: context.platformId,
         communityId: context.communityId,
         timestamp: dayjs().valueOf(),

--- a/src/agent/workflows/impact.ts
+++ b/src/agent/workflows/impact.ts
@@ -136,16 +136,8 @@ export const impactReportWorkflow = new Workflow({
         return digits === 10 || digits === 13;
       }, "Timestamp must be a UNIX timestamp in seconds or milliseconds"),
     platformId: z.string().optional(),
-    communityId: z.string().optional(),
-  }).superRefine((data, ctx) => {
-    if (!data.platformId && !data.communityId) {
-       ctx.addIssue({
-         code: z.ZodIssueCode.custom,
-         path: ["communityId"],
-         message: "communityId should be set if platformId is not.",
-       });
-     }
-  }) ,
+    communityId: z.string(),
+  }),
 });
 
 // Step 1: Fetch messages with stats
@@ -199,8 +191,12 @@ const fetchMessagesStep = new Step({
 
       const platformIds:string[] = [];
       if (context.triggerData.platformId) {
+        // Report is for a specific platform, just add it to the ids to fetch
         platformIds.push(context.triggerData.platformId);
+
       } else {
+        // Report is for a community, get all platforms and add them to the 
+        //  ids to fetch
         const platforms = await db
           .select()
           .from(platformConnections)

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -42,9 +42,10 @@ declare global {
 
   // Define interface for the summary metadata
   interface SummaryMetadata {
+    isCombined: boolean;
     platform?: string;
     platformId?: string;
-    communityId?: string,
+    communityId: string,
     timestamp: number;
     text: string;
     startDate: number;
@@ -91,8 +92,9 @@ declare global {
 
   // Impact Report Types
   interface ImpactReportMetadata {
+    isCombined: boolean;
     platformId?: string;
-    communityId?: string;
+    communityId: string;
     timestamp: number;
     startDate: number;
     endDate: number;


### PR DESCRIPTION
## Description

This PR adds generation of Combined and Platform Impact Reports.

### Changes

- Added new field `isCombined` to Impact Reports and Summaries
- Field `communityId` is now mandatory for all Impact Reports
- Field `platformId` is now `null` for Combined Reports and not `null` for Platform specific reports
- Cron job `src/jobs/generate-impact-report.ts` modified to generate Combined report for each community and Platform reports for each platform in each community.