### PR TITLE
Added modification for Combined Impact Report integration

### DIFF
--- a/src/agent/tools/saveImpactReport.ts
+++ b/src/agent/tools/saveImpactReport.ts
@@ -1,7 +1,10 @@
 import { vectorStore } from "@/agent/stores";
+import { db } from "@/db";
+import { platformConnections } from "@/db/schema";
 import { openai } from "@ai-sdk/openai";
 import { createTool } from "@mastra/core/tools";
 import { embed } from "ai";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 export const saveImpactReportTool = createTool({
@@ -100,10 +103,17 @@ export const saveImpactReportTool = createTool({
         model: openai.embedding("text-embedding-3-small"),
         value: reportText,
       });
+      
+      // Get platform data if is a Platform specific report
+      const platform = context.platformId ? (await db.query.platformConnections.findFirst({
+        where: eq(platformConnections.platformId, context.platformId),
+      })) : null;
 
       const reportMetadata: ImpactReportMetadata = {
         isCombined: context.platformId ? false : true,
         platformId: context.platformId,
+        platformType: platform?.platformType ?? undefined,
+        platformName: platform?.platformName ?? undefined,
         communityId: context.communityId,
         timestamp: Date.now(),
         startDate: context.startDate,

--- a/src/routes/api/v1/reports/index.ts
+++ b/src/routes/api/v1/reports/index.ts
@@ -124,15 +124,19 @@ reportsRoute.openapi(getImpactReportStatus, async (c) => {
 
 reportsRoute.openapi(getImpactReports, async (c) => {
   try {
-    const { platformId, communityId, limit } = c.req.query();
+    const { platformId, communityId, limit, startDate } = c.req.query();
 
-    const topK = limit ? Number.parseInt(limit as string) : 10;
+    const topK = limit ? Number.parseInt(limit as string) : 100;
+
+    // By default retrieve only reports generated in the last 2 days
+    const timestamp = startDate ? Number.parseInt(startDate as string) :
+      dayjs().startOf("day").subtract(2, "day").valueOf();
 
     let filter = undefined;
     if (communityId) {
-      filter = { communityId };
+      filter = { communityId, timestamp: { $gte: timestamp } };
     } else if (platformId) {
-      filter = { platformId };
+      filter = { platformId, timestamp: { $gte: timestamp } };
     }
 
     const results = await vectorStore.query({

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -94,6 +94,8 @@ declare global {
   interface ImpactReportMetadata {
     isCombined: boolean;
     platformId?: string;
+    platformType?: string;
+    platformName?: string;
     communityId: string;
     timestamp: number;
     startDate: number;


### PR DESCRIPTION
## Description
This PR adds some modifications needed to make integration for Combined Impact Reports.

### Changes

- Added a new filter `startDate` to Impact Report endpoint to return only reports generated after some date. By default only reports generated in the last 2 days are returned.
- Added platform name and type to Impact Report generation. We need this information in frontend and is simpler to just save it in the report metadata